### PR TITLE
fix: mail from format

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -11,7 +11,7 @@ locals {
   }
 
   mail_domain = var.email_domain != null ? var.email_domain : var.root_domain
-  mail_from   = "\"NGO Hub\" <no-reply@${local.mail_domain}>"
+  mail_from   = "NGO Hub <no-reply@${local.mail_domain}>"
 
   ngohub = {
     namespace = "ngohub-${var.environment}"


### PR DESCRIPTION
This change should prevent the perpetual diff in `module.ngohub_cognito.aws_cognito_user_pool.this`

```diff
email_configuration {
-    from_email_address : "NGO Hub <no-reply@domain>"
+    from_email_address : "\"NGO Hub\" <no-reply@domain>"
}

